### PR TITLE
Adding ppa:ondrej/php for consistency with our other PHP images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY files /
 RUN \
     apt-get update && \
+    apt-get install -y software-properties-common python-software-properties && \
+    add-apt-repository -y -u ppa:ondrej/php && \
+    apt-get update && \
     apt-get install -y php7.0-cli php7.0-fpm php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite3 php7.0-soap php7.0-xml php7.0-zip php7.0-gettext php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-imap php-imagick && \
     mkdir /tmp/composer/ && \
     cd /tmp/composer && \


### PR DESCRIPTION
Our PHP 5.6 image includes ppa:ondrej/php - not sure why, but some of the images based off it require packages in that repo rather than in the official Ubuntu repo.

Our new PHP 7.1 images require ppa:ondrej/php because 7.1 isn't available in the official Ubuntu repo.

Hence to make everything work in PHP 7.0 without finding a different approach to that used in the other version of PHP we have - we need access to the packages in ppa:ondrej/php